### PR TITLE
Add charset to response Content-Type header

### DIFF
--- a/SimpleHttpServer/HttpProcessor.cs
+++ b/SimpleHttpServer/HttpProcessor.cs
@@ -71,7 +71,12 @@ namespace SimpleHttpServer
             
             // default to text/html content type
             if (!response.Headers.ContainsKey("Content-Type")) {
-                response.Headers["Content-Type"] = "text/html";
+                string type = "text/html";
+                if (!string.IsNullOrWhiteSpace(response.CharsetName))
+                {
+                    type += "; charset=" + response.CharsetName;
+                }
+                response.Headers["Content-Type"] = type;
             }
 
             response.Headers["Content-Length"] = response.Content.Length.ToString();

--- a/SimpleHttpServer/Models/HttpResponse.cs
+++ b/SimpleHttpServer/Models/HttpResponse.cs
@@ -39,6 +39,7 @@ namespace SimpleHttpServer.Models
         public string StatusCode { get; set; }
         public string ReasonPhrase { get; set; }
         public byte[] Content { get; set; }
+        public string CharsetName { get; protected set; }
 
         public Dictionary<string, string> Headers { get; set; }
 
@@ -55,6 +56,7 @@ namespace SimpleHttpServer.Models
             {
                 encoding = Encoding.UTF8;
             }
+            CharsetName = encoding.WebName;
             Content = encoding.GetBytes(content);
         }
 


### PR DESCRIPTION
Including the character set in the Content-Type header is generally needed to ensure correct display of Unicode characters.